### PR TITLE
Sependa repo migration 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,3 +1,6 @@
 platform :ios, '6.0'
 
+source 'https://github.com/CocoaPods/Specs'
+source 'https://github.com/Sependa/cocoapods-specs'
+
 podspec path: 'SalesforceOAuth-Taptera'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - CocoaLumberjack (1.9.2):
-    - CocoaLumberjack/Extensions
+    - CocoaLumberjack/Extensions (= 1.9.2)
   - CocoaLumberjack/Core (1.9.2)
   - CocoaLumberjack/Extensions (1.9.2):
     - CocoaLumberjack/Core
@@ -19,10 +19,10 @@ DEPENDENCIES:
   - SalesforceSecurity-Taptera (= 2.3.1)
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: 205769c032b5fef85b92472046bcc8b7e7c8a817
+  CocoaLumberjack: 628fca2e88ef06f7cf6817309aa405f325d9a6fa
   MKNetworkKit-Salesforce-Taptera: 493e25d82acf3e051cf8f384c13e715acd54725a
-  Reachability: 8e9635e3cb4f98e7f825e51147f677ecc694d0e7
+  Reachability: dd9aa4fb6667b9f787690a74f53cb7634ce99893
   Salesforce-Common-Utils-iOS-Taptera: 1b11fcfbd2c5d1b212690481501f155aef3963c2
   SalesforceSecurity-Taptera: 8d4dfe7201c3c023d5a57ff2d8f559f5502c2033
 
-COCOAPODS: 0.34.4
+COCOAPODS: 0.39.0

--- a/SalesforceOAuth-Taptera.podspec
+++ b/SalesforceOAuth-Taptera.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name = "SalesforceOAuth-Taptera"
-  s.version = "2.3.1"
-  s.summary = "Taptera version of Salesforce OAuth for iOS."
-  s.homepage = "https://github.com/Taptera/SalesforceOAuth.git"
+  s.version = "2.3.2"
+  s.summary = "Sependa version of Salesforce OAuth for iOS."
+  s.homepage = "https://github.com/Sependa/SalesforceOAuth.git"
   s.license      = {:type => 'custom', :file => 'LICENSE.md'}
   s.author = 'Salesforce'
-  s.source = { :git => "https://github.com/Taptera/SalesforceOAuth.git", :tag => "v#{s.version}" }
+  s.source = { :git => "https://github.com/Sependa/SalesforceOAuth.git", :tag => "v#{s.version}" }
   s.platform  = :ios, '6.0'
 
   s.requires_arc = true


### PR DESCRIPTION
What's up:
- updated repo links to Sependa
- bumped version to 2.7.4

---

```
pod lib lint --sources='https://github.com/Sependa/cocoapods-specs,https://github.com/CocoaPods/Specs'  --allow-warnings --use-libraries

 -> SalesforceOAuth-Taptera (2.3.2)
    - WARN  | xcodebuild:  MKNetworkKit-Salesforce-Taptera/MKNetworkKit/MKNetworkOperation.m:1300:27: warning: 'kSecTrustResultConfirm' is deprecated [-Wdeprecated-declarations]
    - NOTE  | xcodebuild:  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator9.3.sdk/System/Library/Frameworks/Security.framework/Headers/SecTrust.h:87:5: note: 'kSecTrustResultConfirm' has been explicitly marked deprecated here
    - WARN  | [iOS] xcodebuild:  MKNetworkKit-Salesforce-Taptera/MKNetworkKit/MKNetworkOperation.m:1353:34: warning: implicit conversion loses integer precision: 'const long long' to 'NSUInteger' (aka 'unsigned int') [-Wshorten-64-to-32]
    - WARN  | [iOS] xcodebuild:  MKNetworkKit-Salesforce-Taptera/MKNetworkKit/MKNetworkOperation.m:1502:12: warning: initialization of pointer of type 'NSCachedURLResponse * _Nullable' to null from a constant boolean expression [-Wbool-conversion]
    - WARN  | [iOS] xcodebuild:  SalesforceSecurity-Taptera/SalesforceSecurity/Classes/SFKeyStoreManager.m:93:123: warning: enum values with underlying type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead [-Wformat]
    - WARN  | [iOS] xcodebuild:  SalesforceSecurity-Taptera/SalesforceSecurity/Classes/SFKeyStoreManager.m:153:123: warning: enum values with underlying type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead [-Wformat]
    - WARN  | [iOS] xcodebuild:  SalesforceSecurity-Taptera/SalesforceSecurity/Classes/SFKeyStoreManager.m:265:123: warning: enum values with underlying type 'NSUInteger' should not be used as format arguments; add an explicit cast to 'unsigned long' instead [-Wformat]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m:300:29: warning: implicit conversion from enumeration type 'enum NSURLCacheStoragePolicy' to different enumeration type 'NSURLRequestCachePolicy' (aka 'enum NSURLRequestCachePolicy') [-Wenum-conversion]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m:386:39: warning: undeclared selector 'objectWithData:' [-Wundeclared-selector]
    - WARN  | xcodebuild:  /Users/aleksanderzubala/Documents/MyProjects/Sependa/pods/SalesforceOAuth/SalesforceOAuth/Classes/SFOAuthCoordinator.m:387:41: warning: undeclared selector 'objectWithString:' [-Wundeclared-selector]

SalesforceOAuth-Taptera passed validation.
```
